### PR TITLE
update total usage plot

### DIFF
--- a/bin/render.sh
+++ b/bin/render.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# to be executed from /data/CCBR_Pipeliner/Tools/spacesavers2/report
+# Usage: bash bin/render_report_biowulf.sh
+module load singularity
+SINGULARITY_CACHEDIR=/data/CCBR_Pipeliner/SIFS
+
+echo "cd /mnt && \
+    Rscript bin/render.R \
+    " |\
+    singularity exec -C -B $PWD:/mnt,/data/CCBR_Pipeliner/userdata/spacesavers2/:/mnt/data docker://nciccbr/spacesavers2:0.1.1 bash

--- a/report.Rmd
+++ b/report.Rmd
@@ -101,11 +101,11 @@ plot_metric_time <- function(dat, y_metric) {
     labs(y = y_metric)
 }
 
-min_bytes_GiB <- 10
+min_user_bytes_GiB <- 10
 panel_summary <- function(dat,
                           folder_path = "/data/CCBR",
                           plot_fcn = plot_metric_time,
-                          min_bytes_GiB = min_bytes_GiB) {
+                          min_bytes_GiB = min_user_bytes_GiB) {
   summary_dat_folder <- dat %>%
     filter(FolderPath == folder_path) %>%
     mutate(TotalBytes_GiB = from_bytes(TotalBytes, 'GiB')) %>% 
@@ -298,7 +298,7 @@ layout_column_wrap(
 p <- disk_usage %>% 
   mutate(datetime = lubridate::as_datetime(datetime)) %>%
   rename(used = used_tib, size = size_tib, avail = avail_tib) %>% 
-  pivot_longer(c(used, size, avail), names_to = 'metric') %>% 
+  pivot_longer(c(used, size), names_to = 'metric') %>% 
   mutate(value = round(value, 2)) %>%
     ggplot(aes(
       x = datetime,
@@ -309,8 +309,8 @@ p <- disk_usage %>%
     geom_line(alpha = 0.7) +
     geom_point(aes(text = glue("{value} TiB"))) +
   scale_x_datetime(labels = date_format("%b %Y")) +
-  scale_color_brewer(palette = "Set1",
-                     breaks = c('size', 'used', 'avail') # enforce order
+  scale_color_brewer(palette = "Set2",
+                     breaks = c('size', 'used') # enforce order
                      ) +
     labs(y = 'TiB', x = '') + 
   theme(legend.title = element_blank())
@@ -322,7 +322,7 @@ card(ggplotly(p, tooltip = "text"))
 ## Summary over time
 
 Usage by top users for each spacesavers metric.
-Only users with at least `r min_bytes_GiB` GiB of total disk usage are shown.
+Only users with at least `r min_user_bytes_GiB` GiB of total disk usage are shown.
 
 ```{r summary_over_time}
 summary_dat_all <- user_dat %>%


### PR DESCRIPTION
Remove 'avail', only show 'used' and 'size'. 

Also add a script to render the report on biowulf without sending via email -- useful for developing and debugging.

Resolves #49 